### PR TITLE
fix ENet.ENet is not a constructor error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import * as ENet from './ENet'
-import * as ENetClient from './ENetClient'
+import ENet from './ENet'
+import ENetClient from './ENetClient'
 export { ENet, ENetClient };


### PR DESCRIPTION
I also did require 
"typescript": "^3.9.7"

and used this config to compile using ./node_modules/typescript/bin/tsc


```
{
    "compilerOptions": {
        "module": "commonjs",
        "target": "ES2018",
        "lib": [
          "ES2015",
          "ES2016",
          "ES2017",
          "ES2018"
        ],
        "esModuleInterop": true,
        "forceConsistentCasingInFileNames": true,
        "moduleResolution": "node",
        "allowJs": true,
        "outDir": "dist"
    },
    "include": [
        "src/*"
    ],
    "exclude": []
}
```